### PR TITLE
feat: add kubestellar/homebrew-tap to formula catalog

### DIFF
--- a/formula.json
+++ b/formula.json
@@ -11,6 +11,10 @@
     {
       "repo": "https://github.com/sidneys/homebrew-homebrew",
       "description": ""
+    },
+    {
+      "repo": "https://github.com/kubestellar/homebrew-tap",
+      "description": "KubeStellar tools: kc-agent (MCP server for multi-cluster Kubernetes), console, and more"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the [KubeStellar Homebrew tap](https://github.com/kubestellar/homebrew-tap) to the formula catalog.

## What's in the tap?

The `kubestellar/homebrew-tap` provides Homebrew formulas for AI-powered Kubernetes management tools:

- **kc-agent** — MCP server that bridges AI agents (Claude Desktop, Cursor, etc.) to multi-cluster Kubernetes environments. Exposes pods, deployments, services, nodes, and events across all kubeconfig contexts.
- **kubestellar-console** — Open-source, AI-powered multi-cluster Kubernetes dashboard with guided install missions for 250+ CNCF projects.
- **kubestellar-deploy** — Deployment helper for KubeStellar multi-cluster platform.
- **kubestellar-ops** — Operations toolkit for KubeStellar environments.

## Install

```bash
brew tap kubestellar/tap
brew install kc-agent
```

Or directly:
```bash
brew install kubestellar/tap/kc-agent
```

**Source**: https://github.com/kubestellar/console
**Demo**: https://console.kubestellar.io

## Summary by Sourcery

New Features:
- Expose KubeStellar Homebrew tap formulas (including kc-agent and related tools) through the formula catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formula repository configuration with a new tap entry and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->