### PR TITLE
Update BrewMate to 1.0.22

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.21"
+  version '1.0.22'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.21/BrewMate-1.0.21-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "f8cd687bfd62843fb968749b39de4dc39bd72e0d1d12d7e77ebc54bb07c16002"
+  sha256 'ea88d1851c0ecd16461b1429a33defec0361c360d9cfadaa81efd9c7fdb828d2'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _f171e96d379dea79e317b742e4f50a2b4d1d634f_.

## Summary by Sourcery

Bump the BrewMate cask to the latest 1.0.22 release.

Enhancements:
- Update the BrewMate cask version metadata to 1.0.22.
- Refresh the BrewMate cask checksum for the new release artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated brewmate to version 1.0.22 in Homebrew cask metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->