### PR TITLE
Update BrewMate to 1.0.24

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.22"
+  version '1.0.24'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.22/BrewMate-1.0.22-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "ba37f3315e5dd08e756ccb936125ef98bbb5628d6ca5c9207c7dd2d7fba94279"
+  sha256 'd3224342ffd35c6103bbadfea2cd4d58a35ccfbe18d81fb63cc31d63833cea62'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _a3643a60378ea8eba6fbff7c66f23e7a42e90cc5_.

## Summary by Sourcery

Build:
- Update BrewMate cask metadata to reference version 1.0.24 and its new SHA-256 checksum.