### PR TITLE
Update BrewMate to 1.0.24

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.24"
+  version '1.0.24'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.24/BrewMate-1.0.24-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "e7a444d230a1d881d85e1a3bc3b66283678c65b81d104a579c8a496280453f2d"
+  sha256 '981f78d4c6ffb59909bc045fca560142ece9ac409f1ef84db044c7da6139f375'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _c58f27be31f24e47d097ec4b4c8376c324dbb6e1_.

## Summary by Sourcery

Update the BrewMate cask metadata to use the latest checksum and align string quoting style for the version field.

Enhancements:
- Refresh the BrewMate cask SHA-256 checksum to match the current 1.0.24 release artifact.
- Standardize the version declaration to use single quotes for consistency with the rest of the cask.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the integrity verification hash for brewmate version 1.0.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->