### PR TITLE
Update BrewMate to 1.0.24

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.24"
+  version '1.0.24'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.24/BrewMate-1.0.24-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "e7a444d230a1d881d85e1a3bc3b66283678c65b81d104a579c8a496280453f2d"
+  sha256 'dbde6522b37ce6f7bbd462cbea91e72f6846642fab63c6834c31aea4a13e2aff'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _1d5153b0a7c8f532004ccf88cbc3907702d111af_.

## Summary by Sourcery

Update the BrewMate cask metadata for the 1.0.24 release.

Enhancements:
- Refresh the BrewMate cask checksum to match the current 1.0.24 release artifact.
- Align version and checksum fields to use consistent single-quote style in the cask definition.