### PR TITLE
Update BrewMate to 1.0.25

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.25"
+  version '1.0.25'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.25/BrewMate-1.0.25-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "1b9a96a91952939479b2a396560e4e02093a4e645b4d97b5635aab932dc947b1"
+  sha256 '88992f2e23cc13f94374e5807f55393d40dee19945add62b7581e79b50a2c453'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _6f2f2248c6e93d1ce02fe37eca37377b52b21872_.

## Summary by Sourcery

Enhancements:
- Align BrewMate cask version and checksum with the current 1.0.25 release artifact.