### PR TITLE
Update BrewMate to 1.0.25

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.25"
+  version '1.0.25'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.25/BrewMate-1.0.25-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "1b9a96a91952939479b2a396560e4e02093a4e645b4d97b5635aab932dc947b1"
+  sha256 'dff6460918a303e97a9c296facbf9f876e19850b7876739375c2d5a8d7eb8c29'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _769ce622d69095337c757a33c0f0396d8be0f12d_.

## Summary by Sourcery

Enhancements:
- Refresh the BrewMate cask checksum for the 1.0.25 universal dmg and align string quoting style.