### PR TITLE
Update BrewMate to 1.0.27

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.26"
+  version '1.0.27'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.26/BrewMate-1.0.26-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "f6cb19c464e10ae52c206d8f8e4ad54795a74f7f658d143efd848fb4780370ea"
+  sha256 'b927e2b773eaa8ef7dfbd967d27a7dde2b270dba0db9e7db037956169f970c14'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _becdc6336247780bbb21af5229946c8f6e8db660_.

## Summary by Sourcery

Enhancements:
- Bump BrewMate cask version and checksum to 1.0.27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated distribution configuration to make version 1.0.27 available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->