### PR TITLE
Update BrewMate to 1.0.28

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.27"
+  version '1.0.28'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.27/BrewMate-1.0.27-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "a6f4911d58547ab4b2991afeb01050901f61ed6f3a264749438aef2745bdf3b0"
+  sha256 'a09817c85a1f691f62e139406f427e5f893640abb1007da53b8ef309466a71af'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _2c9919f63e4f8dd74176ef6da9fd5272aa9a7617_.

## Summary by Sourcery

Build:
- Update BrewMate cask metadata to reference version 1.0.28 and its new SHA-256 checksum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated brewmate to version 1.0.28 with updated package checksum verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->