### PR TITLE
Update BrewMate to 1.0.29

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.28"
+  version '1.0.29'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.28/BrewMate-1.0.28-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "25594fe2b350a1dc76a33262c18d5a6938813b2cfc259f5e4ef1e9efe87fcf2d"
+  sha256 '0e9454a776d5b72b05ea78afc6669d96a256d0b7ccd3ebd54d612e97e5aa56e9'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _c0ef20421ca98de481e465a9938ea94f2b3d03ef_.

## Summary by Sourcery

Build:
- Update the BrewMate cask definition to reference the new 1.0.29 release artifact and checksum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated brewmate cask metadata to version 1.0.29 and refreshed the download verification information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->