### PR TITLE
Update BrewMate to 1.0.29

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.29"
+  version '1.0.29'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.29/BrewMate-1.0.29-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "650b482fd1646b2c710387d5ee1974a92c489ebb947f49b49e17ce7726256f0f"
+  sha256 'bdaf9a06a86de67b7410ab3c94cdb707b310c34f43321a84ef031cd5ed11b79d'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _c8bd2334a6706ffd110f86acb52bb7fb39601d34_.

## Summary by Sourcery

Correct the BrewMate cask definition for version 1.0.29

Enhancements:
- Update the BrewMate cask checksum to match the 1.0.29 release asset
- Align string quoting style for version and checksum fields in the cask file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package integrity verification metadata for brewmate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->