### PR TITLE
Update BrewMate to 1.0.29

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.29"
+  version '1.0.29'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.29/BrewMate-1.0.29-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "650b482fd1646b2c710387d5ee1974a92c489ebb947f49b49e17ce7726256f0f"
+  sha256 '16ce95774cf2c7d1a3310a97890c48a8087699db43567e387a2e151a10baa58d'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _375de8ac17759a3b5675f32d3e233af568e48580_.

## Summary by Sourcery

Bug Fixes:
- Correct the BrewMate 1.0.29 cask checksum to match the released DMG.