### PR TITLE
Update BrewMate to 1.0.29

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.29"
+  version '1.0.29'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.29/BrewMate-1.0.29-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "650b482fd1646b2c710387d5ee1974a92c489ebb947f49b49e17ce7726256f0f"
+  sha256 '6dca4ea5bc72927857dd3d44c98cd8c0d87992ff8f1e28b60852ccc9ae73b7b8'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _593c6563b40f799c2dfea1c0796119238cf3688f_.

## Summary by Sourcery

Enhancements:
- Refresh the BrewMate 1.0.29 cask metadata, including checksum, to align with the current release.