### PR TITLE
Update BrewMate to 1.0.29

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.29"
+  version '1.0.29'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.29/BrewMate-1.0.29-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "def1db1d657758031545a61244ff99752a0560380042f92654126c9892fc05a8"
+  sha256 'dac54277832f6310e43127d76831d51bf2dd70d49908e4762a54c1be63ca2af1'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _855886c9bf836df71b08948837989c65a8f0b095_.

## Summary by Sourcery

Enhancements:
- Refresh BrewMate 1.0.29 cask checksum to the current universal DMG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app package metadata with a new checksum for the current release.
  * Kept the app version and download link unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->