### PR TITLE
Update BrewMate to 1.0.29

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.29"
+  version '1.0.29'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.29/BrewMate-1.0.29-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "def1db1d657758031545a61244ff99752a0560380042f92654126c9892fc05a8"
+  sha256 '600f3c2ade4e32a9cb50c7fa2084b8528b4297ec846204f283fae5325dc23f42'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _793f6db4b36ef6000e3083097362199576c0fdfb_.

## Summary by Sourcery

Build:
- Refresh the BrewMate cask SHA-256 checksum to match the current 1.0.29 universal DMG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Homebrew package to version 1.0.29.
  * Refreshed the download link and checksum to match the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->