### PR TITLE
Update BrewMate to 1.0.33

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.32"
+  version '1.0.33'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.32/BrewMate-1.0.32-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "cc363dab6242c1111e9e3a03817c1b9434089bb20b67e3d7f6daca30e59f8c15"
+  sha256 'b1f11d9bcb6a1b64a24207551bdafdf4186621c1a4640edcd79c61fcdd9bf997'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _73b32a84d2e4abea92b7c74972e4d7a067fc8233_.

## Summary by Sourcery

Bump the BrewMate cask to version 1.0.33, updating the version metadata and checksum for the new release artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Brewmate package to the latest version, so Homebrew installs now pull in the newest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->