### PR TITLE
Update BrewMate to 1.0.33

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.33"
+  version '1.0.33'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.33/BrewMate-1.0.33-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "0bf3feb8b1f40cb65867c7042c2805e11882a8bf2b5191c4e22cca08f717aaaa"
+  sha256 '6f2725507ef2ec3f86bb14dc84d0db778ee7a2ff869eb87a134b832087e52885'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _8767d97e1a8faf24b0c921f99293dbaf04336642_.

## Summary by Sourcery

Enhancements:
- Refresh the BrewMate cask SHA256 to match the current 1.0.33 universal DMG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated BrewMate to version 1.0.33.
  * Updated the download package and verification checksum for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->