### PR TITLE
Update BrewMate to 1.0.33

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.33"
+  version '1.0.33'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.33/BrewMate-1.0.33-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "0bf3feb8b1f40cb65867c7042c2805e11882a8bf2b5191c4e22cca08f717aaaa"
+  sha256 '58187fb18a2015ff95c3484e7efb277c3a62ebb3ad82407c54fa890fe15e407b'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _177fe9fa3a85bbe190261ea63b60162ee2cf83ad_.

## Summary by Sourcery

Refresh BrewMate cask metadata for the 1.0.33 release.

Chores:
- Update BrewMate 1.0.33 cask checksum to match the latest release artifact.
- Normalize BrewMate cask string quoting style.