### PR TITLE
Update BrewMate to 1.0.33

### DIFF
--- a/Casks/brewmate.rb
+++ b/Casks/brewmate.rb
@@ -1,11 +1,11 @@
 cask "brewmate" do
-  version "1.0.33"
+  version '1.0.33'
 
   url "https://github.com/romankurnovskii/BrewMate/releases/download/1.0.33/BrewMate-1.0.33-universal.dmg"
   name "BrewMate"
   desc "Homebrew GUI apps manager"
   homepage "https://github.com/romankurnovskii/BrewMate"
-  sha256 "a2d0eab0fba6de62c7978a5a92a193fc95aead76a87c5fed6ede29d556360e90"
+  sha256 '145a9d19c8b289565083f62d05882bc1309bbb35f3bf1cf4bda6606209a64fc4'
 
   auto_updates true
 


### PR DESCRIPTION
**Release**. 

commit: _c9fbc7bbcb66deb358e7df972aa1d199ffaeb34c_.

## Summary by Sourcery

Build:
- Refresh BrewMate 1.0.33 cask metadata, including the release checksum.