### PR TITLE
fix(formula): remove disabled depends_on macos: :mojave from mkvtoolnix

### DIFF
--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -34,7 +34,6 @@ class Mkvtoolnix < Formula
   depends_on "libmatroska"
   depends_on "libogg"
   depends_on "libvorbis"
-  depends_on macos: :mojave # C++17
   depends_on "pcre2"
 
   uses_from_macos "libxslt" => :build


### PR DESCRIPTION
Fixes #129

## Summary
- Removes  from .
- In modern Homebrew, calling  is disabled because Mojave is EOL, causing Homebrew to throw a import error ().
- Resolves issue #129 (and completes the change originally intended in PR #100 / issue #99).

## Summary by Sourcery

Bug Fixes:
- Fix mkvtoolnix formula failures caused by referencing a disabled macOS Mojave dependency in current Homebrew.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an obsolete macOS Mojave-specific dependency from the MKVToolNix installation formula.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->