### PR TITLE
Add mead (native Homebrew GUI for macOS)

### DIFF
--- a/casks.json
+++ b/casks.json
@@ -679,6 +679,10 @@
     {
       "description": "Homebrew GUI apps manager",
       "repo": "https://github.com/romankurnovskii/BrewMate"
+    },
+    {
+      "description": "Native Homebrew GUI for macOS",
+      "repo": "https://github.com/DaKiLloTh/homebrew-mead"
     }
   ],
   "skip": [


### PR DESCRIPTION
mead is a free, open-source native macOS GUI for Homebrew (Go + Wails + React): browse/search/install/update formulae and casks, manage taps and services, CVE scanning, all without the terminal. Has its own Homebrew tap at DaKiLloTh/homebrew-mead, so adding it under `casks` alongside the other GUI-manager entries (BrewMate etc).

- App: https://github.com/DaKiLloTh/mead
- Site: https://getmead.app

## Summary by Sourcery

New Features:
- Add the mead native macOS Homebrew GUI to the cask catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Mead, a native macOS GUI application, to the available Homebrew casks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->