### PR TITLE
feat: add etemaro CLI formula, update desktop cask to v3.6.0

### DIFF
--- a/Casks/etemaro.rb
+++ b/Casks/etemaro.rb
@@ -1,11 +1,11 @@
 cask "etemaro" do
-  version "v3.4.4"
+  version "v3.6.0"
 
-  url "https://github.com/romankurnovskii/etemaro/releases/download/v3.4.4/Etemaro_0.2.0_universal.dmg"
+  url "https://github.com/romankurnovskii/etemaro/releases/download/v3.6.0/Etemaro_0.2.0_universal.dmg"
   name "etemaro"
   desc "LLM-powered agent that autonomously manages liquidity positions on Meteora DLMM for Solana"
   homepage "https://github.com/romankurnovskii/etemaro"
-  sha256 "74407cadfbe50594d08e1651b6431b4bbbbe50d4d45a9b3b58f414cfdb0d3bd9"
+  sha256 "baf1ac669e5b2030eb3c03e694fb2fa9b8c907c5641fb0c1c6a81210e1cd92ae"
 
   auto_updates true
 

--- a/Formula/etemaro.rb
+++ b/Formula/etemaro.rb
@@ -1,0 +1,18 @@
+class Etemaro < Formula
+  desc "Autonomous DLMM LP agent for Meteora on Solana"
+  homepage "https://github.com/romankurnovskii/etemaro"
+  version "3.6.0"
+  url "https://registry.npmjs.org/@etemaro/cli/-/cli-3.6.0.tgz"
+  sha256 "1e4de468a2cb1b0df52d5ca4dc75ef9756544232b95c543b93a06af7e9507ecd"
+
+  depends_on "node"
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"dist/Cli.cjs" => "etemaro"
+  end
+
+  test do
+    system "#{bin}/etemaro", "help"
+  end
+end


### PR DESCRIPTION
## Changes
- Add `Formula/etemaro.rb` — Homebrew formula for `@etemaro/cli` v3.6.0 (npm-based)
- Update `Casks/etemaro.rb` — Desktop app cask from v3.4.4 → v3.6.0

## Notes
- CLI formula uses npm tarball URL (not GitHub release binary) since @etemaro/cli is published to npm
- Desktop cask DMG is universal (arm64 + x64)
- Both the Formula and Cask now resolve correctly via `brew install etemaro` (CLI) and `brew install --cask etemaro` (desktop)

## Summary by Sourcery

Add Homebrew support for the Etemaro CLI and update the desktop application cask to version 3.6.0.

New Features:
- Add a Homebrew formula for installing the Etemaro CLI from its npm package.

Enhancements:
- Update the Etemaro desktop cask to version 3.6.0.

Tests:
- Add a formula test that verifies the CLI responds to the help command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Homebrew installation support for the `etemaro` command-line tool.
  - Included a verification check to confirm the command runs successfully after installation.

- **Updates**
  - Updated the Homebrew cask to release v3.6.0.
  - Updated the download source and integrity verification for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->